### PR TITLE
Fix "critical HDD detection" bug in check_hparray

### DIFF
--- a/check_hparray/check_hparray
+++ b/check_hparray/check_hparray
@@ -133,7 +133,7 @@ case "$1" in
                 exit 0
                 ;;
 	--all)
-		controllers=`sudo -u root hpacucli controller all show | sed 's/.*Slot \([0-9]*\).*/\1/'`
+		controllers=`sudo -u root $HPACUCLI controller all show | sed 's/.*Slot \([0-9]*\).*/\1/'`
 		for i in $controllers ; do sudo -u root $HPACUCLI controller slot=$i pd all show status;done > $TEMPFILE
 		check_raid
 		;;

--- a/check_hparray/check_hparray
+++ b/check_hparray/check_hparray
@@ -81,7 +81,7 @@ check_raid()
 {
         raid_ok=`cat $TEMPFILE |grep -i ok|wc -l`
         raid_warning=`cat $TEMPFILE|grep -i -E  'rebuild|predictive' |wc -l`
-        raid_critical_1=`cat $TEMPFILE|grep -i 'failed|recovery' | wc -l`
+        raid_critical_1=`cat $TEMPFILE|grep -i -E 'failed|recovery' | wc -l`
 
         err_check=`expr $raid_ok + $raid_warning + $raid_critical_1 `
 


### PR DESCRIPTION
Make -E flag consistent between raid_warning and raid_critical_1. This fixed the check on my system.