### PR TITLE
OID change in new ASA firmware

### DIFF
--- a/check_snmp/check_snmp_load.pl
+++ b/check_snmp/check_snmp_load.pl
@@ -42,9 +42,10 @@ my $cisco_cpu_5s = "1.3.6.1.4.1.9.2.1.56.0"; # Cisco CPU load (5sec %)
 
 # Ciscoasa cpu/load
 # Added by palli@ok.is - 2010-03-13
-my $casa_cpu_5m = ".1.3.6.1.4.1.9.9.109.1.1.1.1.5.1"; # Cisco CPU load (5min %)
-my $casa_cpu_1m = ".1.3.6.1.4.1.9.9.109.1.1.1.1.4.1"; # Cisco CPU load (1min %)
-my $casa_cpu_5s = ".1.3.6.1.4.1.9.9.109.1.1.1.1.3.1"; # Cisco CPU load (5sec %)
+# Edited by vallifudd@gmail.com - 2017-93-29
+my $casa_cpu_5m = ".1.3.6.1.4.1.9.9.109.1.1.1.1.8.1"; # Cisco CPU load (5min %)
+my $casa_cpu_1m = ".1.3.6.1.4.1.9.9.109.1.1.1.1.7.1"; # Cisco CPU load (1min %)
+my $casa_cpu_5s = ".1.3.6.1.4.1.9.9.109.1.1.1.1.10.1"; # Cisco CPU load (5sec %)
 
 # Cisco catalyst cpu/load
 


### PR DESCRIPTION
"the reason for the OID change is due to the multi-core architecture of ASA-5515-x"

[284]   1.3.6.1.4.1.9.9.109.1.1.1.1.2.  cpmCPUTotalPhysicalIndex
[285]   1.3.6.1.4.1.9.9.109.1.1.1.1.7.  cpmCPUTotal1minRev
[286]   1.3.6.1.4.1.9.9.109.1.1.1.1.8.  cpmCPUTotal5minRev
[287]   1.3.6.1.4.1.9.9.109.1.1.1.1.9.  cpmCPUMonInterval
[288]   1.3.6.1.4.1.9.9.109.1.1.1.1.10. cpmCPUTotalMonIntervalValue
[289]   1.3.6.1.4.1.9.9.109.1.1.1.1.11. cpmCPUInterruptMonIntervalValue
[293]   1.3.6.1.4.1.9.9.109.1.2.4.1.2.  cpmCPURisingThresholdValue
[294]   1.3.6.1.4.1.9.9.109.1.2.4.1.3.  cpmCPURisingThresholdPeriod